### PR TITLE
Removed validate() method to allow the use of EnvVars for the plugins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/checkmarx/ast/wrapper/CxConfig.java
+++ b/src/main/java/com/checkmarx/ast/wrapper/CxConfig.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -13,7 +12,7 @@ import java.util.regex.Pattern;
 
 @Data
 @Builder
-public class  CxConfig {
+public class CxConfig {
 
     private static final Pattern pattern = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");
 
@@ -29,17 +28,6 @@ public class  CxConfig {
 
     public void setAdditionalParameters(String additionalParameters) {
         this.additionalParameters = parseAdditionalParameters(additionalParameters);
-    }
-
-    void validate() throws InvalidCLIConfigException {
-        if (StringUtils.isBlank(getBaseUri())) {
-            throw new InvalidCLIConfigException("Checkmarx server URL is not set");
-        }
-
-        if (StringUtils.isBlank(getApiKey())
-            && (StringUtils.isBlank(getClientId()) || StringUtils.isBlank(getClientSecret()))) {
-            throw new InvalidCLIConfigException("Credentials are not set");
-        }
     }
 
     List<String> toArguments() {

--- a/src/main/java/com/checkmarx/ast/wrapper/CxWrapper.java
+++ b/src/main/java/com/checkmarx/ast/wrapper/CxWrapper.java
@@ -42,7 +42,6 @@ public class CxWrapper {
 
     public CxWrapper(@NonNull CxConfig cxConfig, @NonNull Logger logger) throws CxConfig.InvalidCLIConfigException,
             IOException {
-        cxConfig.validate();
         this.cxConfig = cxConfig;
         this.logger = logger;
         this.executable = StringUtils.isBlank(this.cxConfig.getPathToExecutable())
@@ -305,7 +304,7 @@ public class CxWrapper {
 
     }
 
-    public kicsRealtimeResults kicsRealtimeScan(@NonNull String fileSources,String engine ,String additionalParams)
+    public kicsRealtimeResults kicsRealtimeScan(@NonNull String fileSources, String engine, String additionalParams)
             throws IOException, InterruptedException, CxException {
         this.logger.info("Executing 'scan kics-realtime' command using the CLI.");
         this.logger.info("Fetching the results for fileSources {} and additionalParams {}", fileSources, additionalParams);
@@ -317,7 +316,7 @@ public class CxWrapper {
         arguments.add(fileSources);
         arguments.add(CxConstants.ADDITONAL_PARAMS);
         arguments.add(additionalParams);
-        if(engine.length()>0){
+        if (engine.length() > 0) {
             arguments.add(CxConstants.ENGINE);
             arguments.add(engine);
         }
@@ -325,6 +324,7 @@ public class CxWrapper {
         return kicsResults;
 
     }
+
     private int getIndexOfBfLNode(List<Node> bflNodes, List<Node> resultNodes) {
 
         int bflNodeNotFound = -1;


### PR DESCRIPTION
Validate() method restricted the blank values for base url, apikey , client-id and client-secret. This caused a problem in the plugins when Envvars were used to store the client-id and client secret.