### PR TITLE
change auth test case during failure

### DIFF
--- a/src/test/java/com/checkmarx/ast/AuthTest.java
+++ b/src/test/java/com/checkmarx/ast/AuthTest.java
@@ -1,15 +1,17 @@
 package com.checkmarx.ast;
 
 import com.checkmarx.ast.wrapper.CxConfig;
+import com.checkmarx.ast.wrapper.CxConstants;
 import com.checkmarx.ast.wrapper.CxException;
 import com.checkmarx.ast.wrapper.CxWrapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 class AuthTest extends BaseTest {
-
     @Test
     void testAuthValidate() throws CxException, IOException, InterruptedException {
         Assertions.assertNotNull(wrapper.authValidate());
@@ -19,6 +21,7 @@ class AuthTest extends BaseTest {
     void testAuthFailure() {
         CxConfig cxConfig = getConfig();
         cxConfig.setBaseAuthUri("wrongAuth");
+        cxConfig.setApiKey("InvalidApiKey");
         Assertions.assertThrows(CxException.class, () -> new CxWrapper(cxConfig, getLogger()).authValidate());
     }
 }


### PR DESCRIPTION
Change the auth validate failure test case to add an invalid API key