### PR TITLE
AST-37667 added ability to send the agent in the results command

### DIFF
--- a/src/main/java/com/checkmarx/ast/wrapper/CxWrapper.java
+++ b/src/main/java/com/checkmarx/ast/wrapper/CxWrapper.java
@@ -263,6 +263,10 @@ public class CxWrapper {
 
     public String results(@NonNull UUID scanId, ReportFormat reportFormat)
             throws IOException, InterruptedException, CxException {
+        return results(scanId, reportFormat, null);
+    }
+    public String results(@NonNull UUID scanId, ReportFormat reportFormat, String agent)
+            throws IOException, InterruptedException, CxException {
         this.logger.info("Retrieving the scan result for scan id {}", scanId);
 
         String tempDir = Files.createTempDirectory("cx").toAbsolutePath().toString();
@@ -274,7 +278,10 @@ public class CxWrapper {
         arguments.add(fileName);
         arguments.add(CxConstants.OUTPUT_PATH);
         arguments.add(tempDir);
-
+        if (agent != null) {
+            arguments.add(CxConstants.AGENT);
+            arguments.add(agent);
+        }
         return Execution.executeCommand(arguments,
                 logger, tempDir,
                 fileName + reportFormat.getExtension());

--- a/src/test/java/com/checkmarx/ast/ResultTest.java
+++ b/src/test/java/com/checkmarx/ast/ResultTest.java
@@ -55,7 +55,6 @@ class ResultTest extends BaseTest {
         Assertions.assertTrue(scanList.size() > 0);
         String scanId = scanList.get(0).getId();
         Results results = wrapper.results(UUID.fromString(scanId));
-        results.getResults().stream().filter(result -> "sast".equalsIgnoreCase(result.getType())).findFirst();
         Assertions.assertEquals(results.getTotalCount(), results.getResults().size());
     }
 


### PR DESCRIPTION

https://checkmarx.atlassian.net/browse/AST-37667

added ability to send the agent to the results command
the agent used in the results command to display/hide the container results