### PR TITLE
security: harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,24 +32,31 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: cx-public-ubuntu-x64
     outputs:
       CLI_VERSION: ${{ steps.extract_cli_version.outputs.CLI_VERSION }}
       TAG_NAME: ${{ steps.set_tag_name.outputs.TAG_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           lfs: true
 
       - name: Download CLI
         if: inputs.cliTag
+        env:
+          INPUT_CLI_TAG: ${{ inputs.cliTag }}
         run: |
           chmod +x ./.github/scripts/update_cli.sh
-          ./.github/scripts/update_cli.sh ${{ inputs.cliTag }}
+          ./.github/scripts/update_cli.sh "$INPUT_CLI_TAG"
 
       - name: Extract CLI version
         id: extract_cli_version
@@ -57,7 +64,7 @@ jobs:
           CLI_VERSION=$(./src/main/resources/cx-linux version | grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+')
           echo "CLI version being packed is $CLI_VERSION"
           echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "::set-output name=CLI_VERSION::$CLI_VERSION"
+          echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_OUTPUT
 
       - name: Check if CLI version is latest
         if: ${{ github.event.inputs.dev == 'false' && !github.event.inputs.cliTag && github.ref == 'refs/heads/main' }}
@@ -72,31 +79,31 @@ jobs:
           else
             echo "CLI_VERSION ($CLI_VERSION) does not match the latest released version ($LATEST_CLI_VERSION). Failing workflow."
             exit 1
-          fi    
+          fi
 
       - name: Tag
         id: set_tag_name
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          echo ${{ inputs.tag }}
-          tag=${{ inputs.tag }}
-          echo "RELEASE_VERSION=${{ inputs.tag }}" >> $GITHUB_ENV
-          message='${{ inputs.tag }}'
+          echo "$INPUT_TAG"
+          echo "RELEASE_VERSION=$INPUT_TAG" >> $GITHUB_ENV
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -a "${tag}" -m "${message}"
-          git push origin "${tag}"
-          echo "::set-output name=TAG_NAME::${{ inputs.tag }}"
+          git tag -a "$INPUT_TAG" -m "$INPUT_TAG"
+          git push origin "$INPUT_TAG"
+          echo "TAG_NAME=$INPUT_TAG" >> $GITHUB_OUTPUT
 
-      - name: Cache local Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      # - name: Cache local Maven repository
+      #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      #   with:
+      #     path: ~/.m2/repository
+      #     key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-maven-
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@2dfa2011c5b2a0f1489bf9e433881c92c1631f88 # v4.3.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -107,18 +114,21 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Update the POM version.
-        run: mvn -B versions:set -DnewVersion='${{ env.RELEASE_VERSION }}' --file pom.xml -DskipTests
+        run: mvn -B versions:set -DnewVersion="$RELEASE_VERSION" --file pom.xml -DskipTests
 
       - name: Build artifactId property
+        env:
+          INPUT_DEV: ${{ inputs.dev }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           prop=''
-          if [ ${{ inputs.dev }} = true ] && ![ "${{ inputs.tag }}" = "1.0.0-SNAPSHOT" ]; then
+          if [ "$INPUT_DEV" = "true" ] && [ "$INPUT_TAG" != "1.0.0-SNAPSHOT" ]; then
             prop='-Dast.wrapper.id=ast-cli-java-wrapper-dev'
           fi
           echo "AID_PROP=${prop}" >> $GITHUB_ENV
 
       - name: Publish package
-        run: mvn --batch-mode deploy -DskipTests ${{ env.AID_PROP }}
+        run: mvn --batch-mode deploy -DskipTests $AID_PROP
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
@@ -131,26 +141,26 @@ jobs:
           tag_name: ${{ inputs.tag }}
           prerelease: ${{ inputs.dev }}
 
-  notify:
-    if: inputs.dev == false
-    needs: release
-    uses: Checkmarx/plugins-release-workflow/.github/workflows/release-notify.yml@main
-    with:
-      product_name: Java Wrapper
-      release_version: ${{ needs.release.outputs.TAG_NAME }}
-      cli_release_version: ${{ needs.release.outputs.CLI_VERSION }}
-      release_author: "Sypher Team"
-      release_url: https://github.com/Checkmarx/ast-cli-java-wrapper/releases/tag/${{ needs.release.outputs.TAG_NAME }}
-      jira_product_name: JAVA_WRAPPER
-    secrets: inherit
+  # notify:
+  #   if: inputs.dev == false
+  #   needs: release
+  #   uses: Checkmarx/plugins-release-workflow/.github/workflows/release-notify.yml@main
+  #   with:
+  #     product_name: Java Wrapper
+  #     release_version: ${{ needs.release.outputs.TAG_NAME }}
+  #     cli_release_version: ${{ needs.release.outputs.CLI_VERSION }}
+  #     release_author: "Sypher Team"
+  #     release_url: https://github.com/Checkmarx/ast-cli-java-wrapper/releases/tag/${{ needs.release.outputs.TAG_NAME }}
+  #     jira_product_name: JAVA_WRAPPER
+  #   secrets: inherit
 
-  dispatch_auto_release:
-    name: Update Jenkins/Jetbrains/Eclipse Extensions With new Wrapper Version
-    if: inputs.dev == false
-    needs: notify
-    uses: Checkmarx/plugins-release-workflow/.github/workflows/dispatch-workflow.yml@main
-    with:
-      cli_version: ${{ needs.release.outputs.CLI_VERSION }}
-      is_cli_release: false
-      is_java_release: true
-    secrets: inherit
+  # dispatch_auto_release:
+  #   name: Update Jenkins/Jetbrains/Eclipse Extensions With new Wrapper Version
+  #   if: inputs.dev == false
+  #   needs: notify
+  #   uses: Checkmarx/plugins-release-workflow/.github/workflows/dispatch-workflow.yml@main
+  #   with:
+  #     cli_version: ${{ needs.release.outputs.CLI_VERSION }}
+  #     is_cli_release: false
+  #     is_java_release: true
+  #   secrets: inherit


### PR DESCRIPTION
## Summary

- Add explicit permissions: `contents: read` at workflow level, `contents: write` scoped to the `release` job
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT`
- Fix script injection by moving all `inputs.*` and `env.*` context expressions to `env` vars in `run` steps
- Replace `PERSONAL_ACCESS_TOKEN` with `GITHUB_TOKEN`
- Update pinned action SHAs: `actions/checkout` v6.0.3, `actions/setup-java` v5.2.0, `actions/cache` v5.0.5
- Comment out `cache`, `notify`, and `dispatch_auto_release` jobs